### PR TITLE
add "-fomit-frame-pointer" compiler option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ include(CMakeConfig.txt)
 project(pilight)
 set(VERSION 7.0)
 
+add_definitions("-fomit-frame-pointer")
+
 set(MODULESPACK OFF)
 set(CMAKE_BUILD_TYPE Debug)
 


### PR DESCRIPTION
I could not compile pilight out of the box on different plaforms (RPi1, RPi2, BananaPi) because compilation of polarssl failed.
The reason is that in bignum.c the r7 register is used which gcc wants to use for the frame pointer. Details can be found here:

https://tls.mbed.org/kb/development/arm-thumb-error-r7-cannot-be-used-in-asm-here
